### PR TITLE
記事ページの画像最大幅を90%に調整

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -136,6 +136,9 @@ div.post-body p {
 div.post-body img {
   display: block;
   margin: 0 auto;
+  max-width: 90%;
+  height: auto;
+  box-shadow: 0 2px 6px #00000020;
 }
 
 div.post-body {


### PR DESCRIPTION
記事ページの画像がコンテンツ幅をはみ出していたため、最大幅を80%から90%に調整しました。