### PR TITLE
Add Markdown post source support

### DIFF
--- a/docs/markdown-posts.md
+++ b/docs/markdown-posts.md
@@ -1,0 +1,42 @@
+# Markdown Posts
+
+Posts can be stored as Markdown files in content/posts.
+
+The public URL is always derived from the post id:
+
+    /posts/{id}
+
+For migrated posts, keep the original microCMS id. A Markdown post with the
+same id as a microCMS post overrides the microCMS version, so articles can be
+migrated one by one without changing published URLs.
+
+## Frontmatter
+
+    ---
+    id: original-microcms-id
+    title: Article title
+    publishedAt: 2026-05-28T18:00:00+09:00
+    tags:
+      - 技術
+      - AI
+    ---
+
+    Write Markdown here.
+    HTML is also allowed when an embed or old article needs exact rendering.
+
+id, title, and publishedAt are required. If id is omitted, the filename without
+.md is used.
+
+## Export From microCMS
+
+With API_KEY set, export existing posts into Markdown files:
+
+    npm run export:microcms-posts
+
+Existing files are not overwritten. To regenerate every file:
+
+    npm run export:microcms-posts -- --overwrite
+
+The exporter keeps the original article body as HTML inside the Markdown file.
+That preserves rendering first; individual articles can be cleaned up into
+plain Markdown later.

--- a/libs/client.js
+++ b/libs/client.js
@@ -1,6 +1,6 @@
 import { createClient } from 'microcms-js-sdk';
 
-export const client = createClient({
+export const client = process.env.API_KEY ? createClient({
     serviceDomain: 'hiragram',
     apiKey: process.env.API_KEY,
-});
+}) : null;

--- a/libs/generate-rss-feed.ts
+++ b/libs/generate-rss-feed.ts
@@ -1,10 +1,5 @@
 import RSS from 'rss';
-import { createClient } from 'microcms-js-sdk';
-
-export const client = createClient({
-    serviceDomain: 'hiragram',
-    apiKey: process.env.API_KEY!,
-});
+import { getAllPosts } from '@/libs/posts';
 
 const generateFeed = async (): Promise<string> => {
     const feed = new RSS({
@@ -14,13 +9,8 @@ const generateFeed = async (): Promise<string> => {
         language: 'ja',
     });
 
-    const data = await client.get({
-        endpoint: "posts",
-          queries: {
-            limit: 100,
-          },
-      });
-    data.contents
+    const posts = await getAllPosts();
+    posts
     .sort((a: any, b: any) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime())
     .forEach((post: any) => {
         feed.item({

--- a/libs/posts.js
+++ b/libs/posts.js
@@ -1,0 +1,129 @@
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import MarkdownIt from 'markdown-it';
+import { client } from '@/libs/client';
+
+const postsDirectory = path.join(process.cwd(), 'content/posts');
+
+const markdown = new MarkdownIt({
+    html: true,
+    linkify: true,
+    typographer: true,
+});
+
+const normalizeTags = (tags) => {
+    if (Array.isArray(tags)) {
+        return tags;
+    }
+
+    if (typeof tags === 'string') {
+        return tags.split(',').map((tag) => tag.trim()).filter(Boolean);
+    }
+
+    return [];
+};
+
+const normalizeDate = (value) => {
+    if (value instanceof Date) {
+        return value.toISOString();
+    }
+
+    if (typeof value === 'string') {
+        return value;
+    }
+
+    return null;
+};
+
+const getMarkdownPostFiles = () => {
+    if (!fs.existsSync(postsDirectory)) {
+        return [];
+    }
+
+    return fs.readdirSync(postsDirectory).filter((file) => file.endsWith('.md'));
+};
+
+export const getMarkdownPosts = async () => {
+    return getMarkdownPostFiles().map((file) => {
+        const fullPath = path.join(postsDirectory, file);
+        const fileContents = fs.readFileSync(fullPath, 'utf8');
+        const { data, content } = matter(fileContents);
+        const id = data.id || file.replace(/\.md$/, '');
+
+        if (!data.title) {
+            throw new Error(`Missing title in ${fullPath}`);
+        }
+
+        const publishedAt = normalizeDate(data.publishedAt);
+        if (!publishedAt) {
+            throw new Error(`Missing publishedAt in ${fullPath}`);
+        }
+
+        return {
+            id,
+            title: data.title,
+            tags: normalizeTags(data.tags),
+            body: markdown.render(content),
+            publishedAt,
+            updatedAt: normalizeDate(data.updatedAt) || publishedAt,
+            source: 'markdown',
+        };
+    });
+};
+
+export const getMicroCmsPosts = async () => {
+    if (!process.env.API_KEY) {
+        return [];
+    }
+
+    let allPosts = [];
+    let offset = 0;
+    const limit = 100;
+
+    while (true) {
+        const data = await client.get({
+            endpoint: 'posts',
+            queries: { limit, offset },
+        });
+
+        allPosts = [...allPosts, ...data.contents.map((post) => ({
+            ...post,
+            tags: normalizeTags(post.tags),
+            source: 'microcms',
+        }))];
+
+        if (data.contents.length < limit) {
+            break;
+        }
+
+        offset += limit;
+    }
+
+    return allPosts;
+};
+
+export const getAllPosts = async () => {
+    const [microCmsPosts, markdownPosts] = await Promise.all([
+        getMicroCmsPosts(),
+        getMarkdownPosts(),
+    ]);
+
+    const postsById = new Map();
+
+    microCmsPosts.forEach((post) => {
+        postsById.set(post.id, post);
+    });
+
+    // Markdown wins on duplicate IDs, so migrated articles keep /posts/{id}.
+    markdownPosts.forEach((post) => {
+        postsById.set(post.id, post);
+    });
+
+    return Array.from(postsById.values());
+};
+
+export const getPostById = async (id) => {
+    const posts = await getAllPosts();
+    return posts.find((post) => post.id === id) || null;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@vercel/analytics": "^1.3.2",
+        "gray-matter": "^4.0.3",
+        "markdown-it": "^14.2.0",
         "microcms-js-sdk": "^3.1.2",
         "next": "14.2.15",
         "prismjs": "^1.30.0",
@@ -255,6 +257,15 @@
         }
       }
     },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/async-retry": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
@@ -308,17 +319,119 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -331,6 +444,45 @@
       "bin": {
         "loose-envify": "cli.js"
       }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/microcms-js-sdk": {
       "version": "3.1.2",
@@ -476,6 +628,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -529,6 +690,19 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/server-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
@@ -543,12 +717,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/styled-jsx": {
@@ -593,6 +782,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.19.8",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,13 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "export:microcms-posts": "node scripts/export-microcms-posts.mjs",
     "lint": "next lint"
   },
   "dependencies": {
     "@vercel/analytics": "^1.3.2",
+    "gray-matter": "^4.0.3",
+    "markdown-it": "^14.2.0",
     "microcms-js-sdk": "^3.1.2",
     "next": "14.2.15",
     "prismjs": "^1.30.0",

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { useState } from 'react';
-import { client } from '@/libs/client';
+import { getAllPosts } from '@/libs/posts';
 import Layout from '@/components/layout';
 import { formattedDate } from '@/utils/dateFormat';
 
@@ -102,24 +102,7 @@ export default function Home({ posts }) {
 }
 
 export const getStaticProps = async () => {
-    let allPosts = [];
-    let offset = 0;
-    const limit = 100;
-    
-    while (true) {
-        const data = await client.get({
-            endpoint: "posts", 
-            queries: { limit, offset }
-        });
-        
-        allPosts = [...allPosts, ...data.contents];
-        
-        if (data.contents.length < limit) {
-            break;
-        }
-        
-        offset += limit;
-    }
+    const allPosts = await getAllPosts();
 
     return {
         props: {

--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -1,8 +1,7 @@
-import { client } from '@/libs/client';
+import { getAllPosts, getPostById } from '@/libs/posts';
 import Layout from '@/components/layout';
 import { formattedDate } from '@/utils/dateFormat';
 import { useRouter } from 'next/router';
-import { type } from 'os';
 import Head from 'next/head';
 import Script from 'next/script';
 import { useEffect } from 'react';
@@ -127,32 +126,20 @@ export default function PostId({ post }) {
 }
 
 export const getStaticPaths = async () => {
-    let allPosts = [];
-    let offset = 0;
-    const limit = 100;
-    
-    while (true) {
-        const data = await client.get({
-            endpoint: "posts",
-            queries: { limit, offset }
-        });
-        
-        allPosts = [...allPosts, ...data.contents];
-        
-        if (data.contents.length < limit) {
-            break;
-        }
-        
-        offset += limit;
-    }
-    
+    const allPosts = await getAllPosts();
     const paths = allPosts.map((content) => `/posts/${content.id}`);
     return { paths, fallback: false };
 }
 
 export const getStaticProps = async (context) => {
     const id = context.params.id;
-    const data = await client.get({ endpoint: "posts", contentId: id });
+    const data = await getPostById(id);
+
+    if (!data) {
+        return {
+            notFound: true,
+        };
+    }
 
     return {
         props: {

--- a/pages/private/resume.js
+++ b/pages/private/resume.js
@@ -45,6 +45,12 @@ export default function Resume({ resume }) {
 // }
 
 export const getStaticProps = async (context) => {
+    if (!client) {
+        return {
+            notFound: true,
+        };
+    }
+
     const data = await client.get({ endpoint: "resume"});
 
     return {

--- a/scripts/export-microcms-posts.mjs
+++ b/scripts/export-microcms-posts.mjs
@@ -1,0 +1,68 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import matter from 'gray-matter';
+import { createClient } from 'microcms-js-sdk';
+
+const apiKey = process.env.API_KEY;
+const overwrite = process.argv.includes('--overwrite');
+const outputDirectory = path.join(process.cwd(), 'content/posts');
+
+if (!apiKey) {
+    console.error('API_KEY is required to export microCMS posts.');
+    process.exit(1);
+}
+
+const client = createClient({
+    serviceDomain: 'hiragram',
+    apiKey,
+});
+
+const fetchAllPosts = async () => {
+    let allPosts = [];
+    let offset = 0;
+    const limit = 100;
+
+    while (true) {
+        const data = await client.get({
+            endpoint: 'posts',
+            queries: { limit, offset },
+        });
+
+        allPosts = [...allPosts, ...data.contents];
+
+        if (data.contents.length < limit) {
+            break;
+        }
+
+        offset += limit;
+    }
+
+    return allPosts;
+};
+
+fs.mkdirSync(outputDirectory, { recursive: true });
+
+const posts = await fetchAllPosts();
+
+for (const post of posts) {
+    const filePath = path.join(outputDirectory, post.id + '.md');
+
+    if (fs.existsSync(filePath) && !overwrite) {
+        console.log('skip ' + post.id + ': ' + filePath + ' already exists');
+        continue;
+    }
+
+    const file = matter.stringify(post.body || '', {
+        id: post.id,
+        title: post.title,
+        publishedAt: post.publishedAt,
+        updatedAt: post.updatedAt,
+        tags: post.tags || [],
+    });
+
+    fs.writeFileSync(filePath, file);
+    console.log('wrote ' + filePath);
+}
+
+console.log('exported ' + posts.length + ' posts');


### PR DESCRIPTION
## Summary
- Add a shared post loader that returns the same post shape from microCMS and Markdown files.
- Let Markdown posts in content/posts override microCMS posts with the same id, preserving existing /posts/{id} URLs during migration.
- Switch index, post detail, and RSS generation to the shared loader.
- Add a microCMS export script that writes existing posts to Markdown while keeping the original id and HTML body.

## URL preservation
Published URLs remain based on post id: /posts/{id}.
For migrated articles, keep the original microCMS id in frontmatter. If a Markdown file and microCMS article have the same id, the Markdown file wins without changing the route.

## Verification
- npm run build passed.
- npm run lint could not be used because this repo has no ESLint config yet and next lint opens the initial setup prompt.